### PR TITLE
Fixes Issue #1 - IPAddress Rendering

### DIFF
--- a/Adafruit_FeatherOLED_WiFi.cpp
+++ b/Adafruit_FeatherOLED_WiFi.cpp
@@ -90,13 +90,13 @@ void Adafruit_FeatherOLED_WiFi::renderIPAddress ( void )
     if (_connected)
     {
       setCursor(0,24);
-      print((_ipAddress >> 24) & 0xFF, DEC);
-      print(".");
-      print((_ipAddress >> 16) & 0xFF, DEC);
+      print(_ipAddress & 0xFF, DEC);
       print(".");
       print((_ipAddress >> 8) & 0xFF, DEC);
       print(".");
-      print(_ipAddress & 0xFF, DEC);
+      print((_ipAddress >> 16) & 0xFF, DEC);
+      print(".");
+      print((_ipAddress >> 24) & 0xFF, DEC);
     }
   }
 }


### PR DESCRIPTION
Fixes issue #1 where ipaddress octets were rendered backwards in the `Adafruit_FeatherOLED_WiFi::renderIPAddress` method. 
