### PR TITLE
Don't clear bottom row when not rendering IP addr

### DIFF
--- a/Adafruit_FeatherOLED_WiFi.cpp
+++ b/Adafruit_FeatherOLED_WiFi.cpp
@@ -200,8 +200,6 @@ void Adafruit_FeatherOLED_WiFi::renderConnected ( void )
 /******************************************************************************/
 void Adafruit_FeatherOLED_WiFi::renderIPAddress ( void )
 {
-  if (_ipAddressVisible)
-  {
     if (_connected)
     {
       setCursor(0,24);
@@ -213,7 +211,6 @@ void Adafruit_FeatherOLED_WiFi::renderIPAddress ( void )
       print(".");
       print((_ipAddress >> 24) & 0xFF, DEC);
     }
-  }
 }
 
 /******************************************************************************/
@@ -224,10 +221,13 @@ void Adafruit_FeatherOLED_WiFi::renderIPAddress ( void )
 void Adafruit_FeatherOLED_WiFi::refreshIcons ( void )
 {
   fillRect(0, 0, 128, 8, BLACK);
-  fillRect(0, 24, 128, 8, BLACK);
+  if (_ipAddressVisible)
+  {
+    fillRect(0, 24, 128, 8, BLACK);
+    renderIPAddress();
+  }
   renderBattery();
   renderRSSI();
   renderConnected();
-  renderIPAddress();
   display();
 }


### PR DESCRIPTION
Change affects bottom row of display when IP address is not being rendered.
If you are not rendering the IP Address, why blank it out and limit the client to using 3/4ths of the screen.

This would only negatively affect people that were dependent on clearing this area after displaying a full screen of graphics and returning to a screen with the WIFI header (but not showing the IP addr).  

Thanks for considering.