### PR TITLE
Fix getBatteryVoltage()

### DIFF
--- a/Adafruit_FeatherOLED.cpp
+++ b/Adafruit_FeatherOLED.cpp
@@ -177,12 +177,6 @@ float Adafruit_FeatherOLED::getBatteryVoltage() {
     return 0;
   return lc->cellVoltage();
 #else
-  float measuredvbat = analogRead(VBATPIN);
-
-  measuredvbat *= 2;    // we divided by 2, so multiply back
-  measuredvbat *= 3.3;  // Multiply by 3.3V, our reference voltage
-  measuredvbat /= 1024; // convert to voltage
-
-  return measuredvbat * VBAT_MULTIPLIER;
+  return analogRead(VBATPIN) * VBAT_MULTIPLIER;
 #endif
 }

--- a/Adafruit_FeatherOLED_SH110X.cpp
+++ b/Adafruit_FeatherOLED_SH110X.cpp
@@ -180,12 +180,6 @@ float Adafruit_FeatherOLED_SH110X::getBatteryVoltage() {
     return 0;
   return lc->cellVoltage();
 #else
-  float measuredvbat = analogRead(VBATPIN);
-
-  measuredvbat *= 2;    // we divided by 2, so multiply back
-  measuredvbat *= 3.3;  // Multiply by 3.3V, our reference voltage
-  measuredvbat /= 1024; // convert to voltage
-
-  return measuredvbat * VBAT_MULTIPLIER;
+  return analogRead(VBATPIN) * VBAT_MULTIPLIER;
 #endif
 }


### PR DESCRIPTION
For #27.

Tested with Feather M0 Adalogger and Feather OLED SH110X. Readings look more meaningful now at least.